### PR TITLE
Raspberry Pi OSのイメージビルドをDocker container上で完結させる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN apt update \
     git \
     libtool \
     make \
+    wget \
+    cloud-guest-utils \
+    fdisk \
+    gawk \
     && rm -rf /var/lib/apt/lists
 
 # Install git-lfs

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ git submodule update --init
 を実行する。
 
 ### Docker
+次のコマンドを実行することで、コンテナ上で作成されたRaspberry Pi OSのイメージがローカルに置かれる。
 
 ```bash 
 docker build . -t ome2023
-docker run --rm -ti -v $(pwd):/work -v --workdir=/work ome2023 sh -c 'aclocal -I m4 && automake -a -c && autoconf && ./configure --build=x86_64-linux-gnu --host=aarch64-linux-gnu --prefix=/usr/local && make -j6'
-sudo contrib/scripts/install.bash #TODO: run in container
+docker run --rm -ti -v /dev/:/dev --privileged -v $(pwd):/work -v --workdir=/work ome2023 sh -c 'aclocal -I m4 && automake -a -c && autoconf && ./configure --build=x86_64-linux-gnu --host=aarch64-linux-gnu --prefix=/usr/local && make -j6 && ./contrib/scripts/install.bash'
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # IT未来塾講義用 Raspberry Pi OS
 ## Prerequisites
-QEMU > 5.2
-
-QEMU == 3.1+dfsg-8+deb10u9 では apt 実行中にランタイムエラーが起こることを確認している。 QEMU 5.2 と 7.1 で動作確認済み。 https://github.com/docker/buildx/issues/1170
+- Docker Desktop Server https://docs.docker.com/engine/install/ (Desktop でもおそらく可)
 
 ## Image Build
 リポジトリをクローンする


### PR DESCRIPTION
変更点
- `Dockerfile`にビルドに必要なパッケージを追加（wget, cloud-guest-utils, fdisk, gawk）
- `docker run`時に`-v /dev/:/dev --privileged`オプションを追加
- `README`のDocker実行時に叩くコマンドをDocker container上で完結させるように変更