### PR TITLE
Restore Where Directories of `01/`, ... are Placed: `/usr/local/share`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,3 @@
-# SUBDIRS = 01 02 03 04 05 06 07 08 dist
-SUBDIRS = contrib/
-omedatadir = /home/pi/ome
-
 # Run
 #
 # ```
@@ -10,6 +6,9 @@ omedatadir = /home/pi/ome
 #
 # and put the result into below `nobase_dist_omedata_DATA`
 # with newline-escapes whenever you commit new lecture materials.
+
+SUBDIRS = contrib/
+omedatadir = $(datadir)/ome
 nobase_dist_omedata_DATA = \
 01/ps.png \
 01/school.jpg \

--- a/contrib/OpenHSP/Makefile.am
+++ b/contrib/OpenHSP/Makefile.am
@@ -15,21 +15,23 @@ install-exec-local:
 	$(INSTALL_PROGRAM) $(OPENHSPSRCDIR)/$$file "$(DESTDIR)$(bindir)" || exit $$?; \
 	done
 
-APPLICATIONS=$(DESTDIR)$(datarootdir)/applications
-PIXMAPS=$(DESTDIR)$(datarootdir)/pixmaps
+APPLICATIONS=$(datarootdir)/applications
+APPLICATIONS_INSTALL=$(DESTDIR)$(APPLICATIONS)
+PIXMAPS=$(datarootdir)/pixmaps
+PIXMAPS_INSTALL=$(DESTDIR)$(PIXMAPS)
 install-data-local:
-	$(INSTALL) -d $(APPLICATIONS)
-	$(INSTALL) -d $(PIXMAPS)
-	@echo " $(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.desktop '$(APPLICATIONS)'" ;\
-	$(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.desktop "$(APPLICATIONS)"
-	@echo " $(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.png '$(PIXMAPS)'" ;\
-	$(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.png "$(PIXMAPS)"
-	sed -i "s:/usr/share/pixmaps:$(PIXMAPS):g;s:/home/pi/OpenHSP:$(DESTDIR)$(bindir):g" $(APPLICATIONS)/hsed.desktop
+	$(INSTALL) -d $(APPLICATIONS_INSTALL)
+	$(INSTALL) -d $(PIXMAPS_INSTALL)
+	@echo " $(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.desktop '$(APPLICATIONS_INSTALL)'" ;\
+	$(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.desktop "$(APPLICATIONS_INSTALL)"
+	@echo " $(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.png '$(PIXMAPS_INSTALL)'" ;\
+	$(INSTALL_DATA) $(OPENHSPSRCDIR)/hsed.png "$(PIXMAPS_INSTALL)"
+	sed -i "s:/usr/share/pixmaps:$(PIXMAPS):g;s:/home/pi/OpenHSP:$(bindir):g" $(APPLICATIONS_INSTALL)/hsed.desktop
 	sh -c 'cd $(OPENHSPSRCDIR) && find common -type f -exec $(INSTALL_DATA) -D "{}" "$(DESTDIR)$(bindir)/{}" \;'
 
 
 uninstall-local:
 	list='$(OPENHSPTARGETS)'; \
 	@for file in $$list; do echo rm -rf $(DESTDIR)$(bindir)/$$file; rm -rf $(DESTDIR)$(bindir)/$$file || /bin/true; done
-	@echo rm -rf '$(PIXMAPS)/hsed.png'; rm -rf "$(PIXMAPS)/hsed.png" || /bin/true
-	@echo rm -rf '$(APPLICATIONS)/hsed.desktop'; rm -rf "$(APPLICATIONS)/hsed.desktop" || /bin/true
+	@echo rm -rf '$(PIXMAPS_INSTALL)/hsed.png'; rm -rf "$(PIXMAPS_INSTALL)/hsed.png" || /bin/true
+	@echo rm -rf '$(APPLICATIONS_INSTALL)/hsed.desktop'; rm -rf "$(APPLICATIONS_INSTALL)/hsed.desktop" || /bin/true

--- a/contrib/scripts/install.bash
+++ b/contrib/scripts/install.bash
@@ -138,10 +138,7 @@ rm $MOUNT_POINT/home/pi/.config/user-dirs.locale # disable initial check of loca
 ## TODO: summarize dependencies into "control" in a deb package with contesnts of obj (${OBJDIR})and here apt should call that package.
 chroot $MOUNT_POINT apt install -y \
 fcitx-mozc i2c-tools open-jtalk open-jtalk-mecab-naist-jdic hts-voice-nitech-jp-atr503-m001 build-essential zlib1g-dev libsdl2-dev libasound2-dev dnsutils nmap telnet nkf lirc fswebcam gimp vlc tuxtype ruby libgtk2.0-dev libglew-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libgles2-mesa-dev libegl1-mesa-dev open-jtalk open-jtalk-mecab-naist-jdic
-# TODO: `make install` should not run under chroot; otherwise, when the host owns gawk, automake sets AWK=gawk but Raspberry Pi OS does not have gawk but awk.
-# A workaround could be to set AWK=awk but the other dependencies will potentially be broken.
-chroot $MOUNT_POINT su -c "make -C $OBJDIR_EMU AWK=awk install"
-chown -R 1000:1000 $MOUNT_POINT/home/pi/ome
+make DESTDIR=$MOUNT_POINT/usr/local install
 
 # Remove the initial wizard and change pw into `raspberry`
 ## /usr/lib/userconf-pi/userconf calls /usr/bin/cancel-rename and then

--- a/contrib/scripts/install.bash
+++ b/contrib/scripts/install.bash
@@ -112,6 +112,7 @@ make DESTDIR=$(realpath $MOUNT_POINT) install
 # Place .config/user-dirs.locale with ja_JP in /etc/skel to supress locale-inconsistent dialogue.
 ## piwiz creates a new user by moving the default user pi: `usermod -m -d "/home/$NEWNAME" "$NEWNAME"`.
 ## as in userconf-pi/userconf.
+chroot $MOUNT_POINT su pi -c 'LANG=C xdg-user-dirs-update'
 mkdir -p /home/pi/.config
 echo "ja_JP" > /home/pi/.config/user-dirs.locale
 

--- a/contrib/scripts/install.bash
+++ b/contrib/scripts/install.bash
@@ -138,7 +138,7 @@ rm $MOUNT_POINT/home/pi/.config/user-dirs.locale # disable initial check of loca
 ## TODO: summarize dependencies into "control" in a deb package with contesnts of obj (${OBJDIR})and here apt should call that package.
 chroot $MOUNT_POINT apt install -y \
 fcitx-mozc i2c-tools open-jtalk open-jtalk-mecab-naist-jdic hts-voice-nitech-jp-atr503-m001 build-essential zlib1g-dev libsdl2-dev libasound2-dev dnsutils nmap telnet nkf lirc fswebcam gimp vlc tuxtype ruby libgtk2.0-dev libglew-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libgles2-mesa-dev libegl1-mesa-dev open-jtalk open-jtalk-mecab-naist-jdic
-make DESTDIR=$MOUNT_POINT/usr/local install
+make DESTDIR=$(realpath $MOUNT_POINT) install
 
 # Remove the initial wizard and change pw into `raspberry`
 ## /usr/lib/userconf-pi/userconf calls /usr/bin/cancel-rename and then


### PR DESCRIPTION
Closes #19, closes #14, closes #21

Revert "put lecture materials (01/, ...) into home directory instead of datadir"

This reverts commit 6549d4c7b98d566baee0029df50d7e223bfb89e4. restore
where directories of 01/, ... are placed: /usr/local/share.

Accordingly, I had `make install` run outside `chroot` (#19).