### PR TITLE
use wait in all examples instead of await

### DIFF
--- a/03/button_led.hsp
+++ b/03/button_led.hsp
@@ -10,5 +10,5 @@
 *led
 	btn1 = gpioin(5)
 	if btn1==0 : gpio 18, 1 : else : gpio 18, 0
-	await 10
+	wait 10
 	goto *led

--- a/03/button_led2.hsp
+++ b/03/button_led2.hsp
@@ -21,5 +21,5 @@
 	}
 	mae_btn = ima_btn
 
-	await 10
+	wait 10
 	goto *hata

--- a/03/button_led3.hsp
+++ b/03/button_led3.hsp
@@ -43,5 +43,5 @@
 	}
 	mae_btn = ima_btn
 
-	await 10
+	wait 10
 	goto *hata

--- a/03/led.hsp
+++ b/03/led.hsp
@@ -9,7 +9,7 @@
 
 *led
 	gpio 17, 1
-	await 100
+	wait 100
 	goto *led
 
 	gpio 17, 0


### PR DESCRIPTION
Closes a portion ofhttps://github.com/OmeSatoFoundation/ome-doc/issues/1

> 3.2.1 ソースコード 3.2.2 ソースコード awaitとwaitが混在しているので、
統一するか違いを説明する