### PR TITLE
use comparater = instead of == in example hsp scripts

### DIFF
--- a/03/button_led.hsp
+++ b/03/button_led.hsp
@@ -9,6 +9,6 @@
 
 *led
 	btn1 = gpioin(5)
-	if btn1==0 : gpio 18, 1 : else : gpio 18, 0
+	if btn1=0 : gpio 18, 1 : else : gpio 18, 0
 	await 10
 	goto *led

--- a/06/julius.hsp
+++ b/06/julius.hsp
@@ -29,7 +29,7 @@ sdim words, 4096, 0
 ddim cm, 0
 
 repeat -1
-  if is_recieved(sockidx) == 0 {
+  if is_recieved(sockidx) = 0 {
     get_word_list words, cm
     len =  "L1 " + length(words)
     repeat length(words)


### PR DESCRIPTION
Closes an item of
https://github.com/OmeSatoFoundation/ome-doc/issues/1

> 3.3.1 ソースコード 等号比較演算子は == ではなく = でよいので後者に統一