### PR TITLE
prepend $(DESTDIR) into $(prefix) manually in Julius

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,1 +1,18 @@
-SUBDIRS = Julius Dictationkit OpenHSP FaBo JuliusMisc IR OpenJTalk
+JULIUS_DIR = Julius
+SUBDIRS = Dictationkit OpenHSP FaBo JuliusMisc IR OpenJTalk
+
+all-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) all
+check-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) check
+clean-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) clean
+distclean-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) distclean
+
+install-exec-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) install
+install-data-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) install
+uninstall-local:
+	cd $(JULIUS_DIR) && $(MAKE) prefix=$(DESTDIR)$(prefix) $(AM_MAKEFLAGS) uninstall


### PR DESCRIPTION
Julius は Automake を使用せずに Makefile.in を直接実装していおり、
`$(DESTDIR)` のサポートがない。これは `--prefix` と `DESTDIR` の二段階を使った
クロスコンパイルを難しくし、正しい場所に Julius のバイナリがインストールされない。

SUBDIR として Julius を指定している上レベルのラッパ `contrib/Makefile.am` で
DESTDIR の機能をラップすることで、正しい場所に Julius のバイナリをインストールさせている。