### PR TITLE
赤外線の送受信をRPi400に対応

### DIFF
--- a/contrib/scripts/install.bash
+++ b/contrib/scripts/install.bash
@@ -132,6 +132,12 @@ echo "ja_JP" > /home/pi/.config/user-dirs.locale
 chroot $MOUNT_POINT raspi-config nonint do_spi 0
 chroot $MOUNT_POINT raspi-config nonint do_i2c 0
 
+# Enable IR device
+sed -i -e "s/#dtoverlay=gpio-ir,gpio_pin=17/dtoverlay=gpio-ir,gpio_pin=4/g" $MOUNT_POINT/boot/config.txt
+sed -i -e "s/#dtoverlay=gpio-ir-tx,gpio_pin=18/dtoverlay=gpio-ir-tx,gpio_pin=13/g" $MOUNT_POINT/boot/config.txt
+sed -i -e "s/driver *= *devinput/driver = default/g" $MOUNT_POINT/etc/lirc/lirc_options.conf
+sed -i -e "s/device *= *auto/device = \/dev\/lirc0/g" $MOUNT_POINT/etc/lirc/lirc_options.conf
+
 # release resources
 umount_sysfds
 umount -f -l $MOUNT_POINT/boot


### PR DESCRIPTION
[Raspberry Pi 3からRPi400への移行検証時に洗い出した必要な変更](https://ome-edu.nshimizu.com/index.php?%E6%9C%AA%E6%9D%A5%E5%A1%BE2023%E3%81%AB%E5%90%91%E3%81%91%E3%81%A6%20Raspberry%20Pi%20400%20%E3%81%A7%E8%B5%A4%E5%A4%96%E7%B7%9A%E3%82%92%E9%80%81%E5%8F%97%E4%BF%A1%E3%81%99%E3%82%8B) (internal link)をOS作成スクリプトに反映した。