### PR TITLE
Replace hardcoded paths

### DIFF
--- a/contrib/FaBo/Makefile.am
+++ b/contrib/FaBo/Makefile.am
@@ -1,4 +1,5 @@
-bin_SCRIPTS = oled rpz-sensor spi FaBoOLED_EROLED096
+bin_SCRIPTS = oled rpz-sensor spi
+nobase_bin_SCRIPTS = $(shell find FaBoOLED_EROLED096 -type f)
 # TODO: FaBoOLED_EROLED096 should be on /usr/lib/python3.x/site-packages.
 
 hspcommondir = $(bindir)/common
@@ -7,5 +8,5 @@ hspcommon_DATA = rpz-fabo.as rpz-gpio.as rpz-gpio-cl.as
 #TODO: hspcommondir should be at /usr/share/hsp but edit on hsed required to do so.
 
 install-data-hook:
-	sed -i 's;/home/pi/ome/bin/common;$(hspcommondir);g' $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))
-	sed -i 's;/home/pi/ome/bin;$(bindir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS))
+	sed -i 's;/home/pi/ome/bin/common;$(hspcommondir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS)) $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))
+	sed -i 's;/home/pi/ome/bin;$(bindir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS)) $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))

--- a/contrib/FaBo/Makefile.am
+++ b/contrib/FaBo/Makefile.am
@@ -5,3 +5,7 @@ hspcommondir = $(bindir)/common
 hspcommon_DATA = rpz-fabo.as rpz-gpio.as rpz-gpio-cl.as
 
 #TODO: hspcommondir should be at /usr/share/hsp but edit on hsed required to do so.
+
+install-data-hook:
+	sed -i 's;/home/pi/ome/bin/common;$(hspcommondir);g' $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))
+	sed -i 's;/home/pi/ome/bin;$(bindir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS))

--- a/contrib/OpenJTalk/Makefile.am
+++ b/contrib/OpenJTalk/Makefile.am
@@ -13,3 +13,7 @@ hspcommondir = $(bindir)/common
 hspcommon_DATA = jtalk.as
 
 #TODO: hspcommondir should be at /usr/share/hsp but edit on hsed required to do so.
+
+install-data-hook:
+	sed -i 's;/home/pi/ome/bin/common;$(hspcommondir);g' $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))
+	sed -i 's;/home/pi/ome/bin;$(bindir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS))

--- a/contrib/OpenJTalk/Makefile.am
+++ b/contrib/OpenJTalk/Makefile.am
@@ -15,5 +15,5 @@ hspcommon_DATA = jtalk.as
 #TODO: hspcommondir should be at /usr/share/hsp but edit on hsed required to do so.
 
 install-data-hook:
-	sed -i 's;/home/pi/ome/bin/common;$(hspcommondir);g' $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))
-	sed -i 's;/home/pi/ome/bin;$(bindir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS))
+	sed -i 's;/home/pi/ome/bin/common;$(hspcommondir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS)) $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))
+	sed -i 's;/home/pi/ome/bin;$(bindir);g' $(addprefix $(DESTDIR)$(bindir)/, $(bin_SCRIPTS)) $(addprefix $(DESTDIR)$(hspcommondir)/, $(hspcommon_DATA))

--- a/contrib/OpenJTalk/jtalk.as
+++ b/contrib/OpenJTalk/jtalk.as
@@ -14,7 +14,7 @@
     return
 
   #deffunc setvoice str _voice_name
-    voice_name = "/home/pi/ome/bin/openjtalk/voices/" + _voice_name
+    voice_name = _voice_name
     return
   #deffunc jtsave str sentence, var file
     creattmp output_path


### PR DESCRIPTION
```
yshimmyo@zxp070:~/Documents/ome2023$ sudo grep -R "/home/pi/ome/" . | sort | awk '{print $1}' | uniq
./05/How_To_Register_IR.txt:cp
./06/julius.hsp:init_julius
./06/ledbyvoice.hsp:init_julius
./07/www/webserver.py:
./08/www/webserver.py:
Binary
./contrib/FaBo/rpz-fabo.as:
./contrib/FaBo/rpz-gpio.as:
./contrib/FaBo/rpz-gpio-cl.as:
./contrib/OpenJTalk/jtalk.as:
```

にて，2019 年版の仕様であった `/home/pi/ome/bin` への実行可能教材配置がハードコードされており，
`/usr/local/{bin,share}` 以下に置く今版で動作しなかった．

`make install` 時に，適当に substitute して解決を試みた．