### PR TITLE
第7回 jtalkが出力するファイルが見えないのを修正、第8回 スクレイピングスクリプトの修正

### DIFF
--- a/07/www/cgi-bin/jtalk.hsp
+++ b/07/www/cgi-bin/jtalk.hsp
@@ -8,7 +8,7 @@ mes "<html><head><meta charset=\"utf-8\"></head><body>"
 getqueryval "sentence", sentence
 jtsave sentence, wav_file
 mes "<p>" + sentence + "</p>"
-
-mes "<audio src=\"" + wav_file + "\" type=\"audio/wav\" controls>"
+exec "mv " + wav_file + " out.wav"
+mes "<audio src=\"../out.wav\" type=\"audio/wav\" controls>"
 mes "</body></html>"
 end

--- a/contrib/HTMLParse/htmlparser
+++ b/contrib/HTMLParse/htmlparser
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #encoding:utf-8
 import sys
 import ast
@@ -66,7 +66,7 @@ class HTMLParser:
         for i in self.data:
             if i == None:
                 continue
-            print(i.encode('utf-8'))
+            print(i)
         return 0
 def usage():
     global all_args

--- a/contrib/HTMLParse/weblio.py
+++ b/contrib/HTMLParse/weblio.py
@@ -1,22 +1,23 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #encoding:utf-8
 from __future__ import print_function
 from bs4 import BeautifulSoup
-import urllib2
+import urllib.request
 import sys
 
 def search_meaning(word):
 	url = 'https://ejje.weblio.jp/content/' + word
-	html = urllib2.urlopen(url).read().decode('utf-8')
+	html = urllib.request.urlopen(url).read().decode('utf-8')
 	soup = BeautifulSoup(html, 'html.parser')
-	table = soup.findAll('td', 'content-explanation')
-	return table[0].get_text().encode('utf-8')
+	table = soup.find_all('span', 'content-explanation')
+	return table[0].get_text()
 
 def main():
     argc = len(sys.argv)
     if(argc < 1):
         sys.exit(1)
     meaning = search_meaning(sys.argv[1]).split('、')
+    meaning[0] = meaning[0].replace("\n                ","")
     for i in meaning:
         print(i, end=',')
 if __name__ == '__main__':

--- a/contrib/OpenJTalk/jtalk.as
+++ b/contrib/OpenJTalk/jtalk.as
@@ -26,6 +26,6 @@
     }
     ; ../tmp/tmp.??????
     ; CGI用
-    file = "../" + output_path
+    file = output_path
     return 
 #global


### PR DESCRIPTION
・jtalkのjtsaveで/tmpに保存される音声ファイルがwebserverから見えないので、07/www/にmvし、mv時にout.wavというファイル名に統一
・htmlparserをpython3に対応
・weblioのスクレイピングがうまくいかない問題を修正（2023/07/05に動作確認）