### PR TITLE
Update the top Makefile.am which should follow the #86 change

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -251,6 +251,7 @@ nobase_dist_omedata_DATA = \
 07/www/webserver.py \
 08/amedas.hsp \
 08/amedas_led.hsp \
+08/ascii_table.html \
 08/eki.hsp \
 08/friend.hsp \
 08/.gitignore \
@@ -260,7 +261,6 @@ nobase_dist_omedata_DATA = \
 08/tv.hsp \
 08/weblio.hsp \
 08/wikipedia.hsp \
-08/www/ascii_table.html \
 08/www/cgi-bin/ascii_table.hsp \
 08/www/index.html \
 08/www/webserver.py \


### PR DESCRIPTION
#86 で `ascii_table.html` の配置が変更されたが、
そのさい忘れられていた `Makefile.am` の更新を適用しました。

変更前に発生するエラー:

```
yshimmyo@zxp028:~/Documents/ome2023$ docker run --rm -ti -v /dev/:/dev --privileged -v $(pwd):/work -v --workdir=/work -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent ome2023 sh -c 'make'
Making all in contrib/
(中略)
make[1]: Entering directory '/work'
make[1]: *** No rule to make target '08/www/ascii_table.html', needed by 'all-am'.  Stop.
make[1]: Leaving directory '/work'
make: *** [Makefile:666: all-recursive] Error 1
```