### PR TITLE
remove unreachable codes

### DIFF
--- a/05/pwm.hsp
+++ b/05/pwm.hsp
@@ -15,9 +15,3 @@ loop
 
 await 1
 loop
-
-gpio 17,0
-gpio 18,0
-gpio 22,0
-gpio 27,0
-stop


### PR DESCRIPTION
remove a unreachable block of codes in 05/pwm.hsp.

`onexit` command could be used if leds remaining emission bother users.

http://lhsp.s206.xrea.com/command/onexit.html

Closes #137