### PR TITLE
use pinctrl instead of raspi-gpio for raspi5 bookworm

### DIFF
--- a/contrib/FaBo/rpz-gpio-cl.as
+++ b/contrib/FaBo/rpz-gpio-cl.as
@@ -469,14 +469,13 @@
 ; arguments, and return value are the same with gpio, gpioin
 #deffunc cgpio int _p1, int _p2
     if (_p2 = 0){
-        exec "raspi-gpio set " + _p1 + " op pn dl"
+        exec "pinctrl set " + _p1 + " op pn dl"
     }else{
-        exec "raspi-gpio set " + _p1 + " op pn dh"
+        exec "pinctrl set " + _p1 + " op pn dh"
     }
     return
 #defcfunc cgpioin int _p1
-    exec "raspi-gpio set " + _p1 + "pu"
-    cmdexec "raspi-gpio get " + _p1 + " | grep -o 'level=[01]' | sed 's/level=//g'", s
+    cmdexec "pinctrl lev " + _p1, s
     return int(s)
 
 #global


### PR DESCRIPTION
Fix so that `06/www/cgi-bin/led.hsp` with `06/www/webserver.py` works well.