### PR TITLE
第2回のYolov8インストールスクリプトの修正

### DIFF
--- a/02/material/install_yolov8.sh
+++ b/02/material/install_yolov8.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd ~
 python3 -m venv myenv
 source myenv/bin/activate
 sudo apt update


### PR DESCRIPTION
Fix Yolov8 install script
スクリプトを修正しました、イメージ作成の際にinstall_yolov8.sh に実行権限を付けられますか?